### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Data/Csv.php
+++ b/lib/Horde/Data/Csv.php
@@ -323,17 +323,11 @@ class Horde_Data_Csv extends Horde_Data_Base
             $params['quote'] = '"';
         }
 
-        // Detect Mac line endings.
-        $old = ini_get('auto_detect_line_endings');
-        ini_set('auto_detect_line_endings', 1);
-
         do {
             $row = strlen($params['quote'])
                 ? fgetcsv($file, 0, $params['separator'], $params['quote'], $params['escape'])
                 : fgetcsv($file, 0, $params['separator']);
         } while ($row && is_null($row[0]));
-
-        ini_set('auto_detect_line_endings', $old);
 
         if ($row) {
             $row = (strlen($params['quote']) && strlen($params['escape']))

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Data/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Data/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Data Unit Test">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Data/CsvTest.php
+++ b/test/Horde/Data/CsvTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Data_CsvTest extends PHPUnit_Framework_TestCase
+class Horde_Data_CsvTest extends Horde_Test_Case
 {
     public function testImportFile()
     {

--- a/test/Horde/Data/GetCsvTest.php
+++ b/test/Horde/Data/GetCsvTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Data_GetCsvTest extends PHPUnit_Framework_TestCase
+class Horde_Data_GetCsvTest extends Horde_Test_Case
 {
     protected function readCsv($file, $conf = array())
     {

--- a/test/Horde/Data/phpunit.xml
+++ b/test/Horde/Data/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-data/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Add 1011_php8.1.patch. Don't use auto_detect_line_endings anymore. https://salsa.debian.org/horde-team/php-horde-data/-/blob/debian-sid/debian/patches/1011_php8.1.patch
